### PR TITLE
Change Open Graph image URL to static logo

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
     description: siteConfig.description,
     images: [
       {
-        url: buildOgImageUrl({ title: siteConfig.name }),
+        url: /public/logo.png,
         width: 1200,
         height: 630,
         alt: siteConfig.name,
@@ -48,7 +48,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: siteConfig.name,
     description: siteConfig.description,
-    images: [buildOgImageUrl({ title: siteConfig.name })],
     creator: siteConfig.twitterHandle,
   },
   robots: {


### PR DESCRIPTION
Updated Open Graph image URL to use a static logo.